### PR TITLE
Boot fix for RPi 3B, 3B+

### DIFF
--- a/kernel/boot/device_tree.c
+++ b/kernel/boot/device_tree.c
@@ -463,20 +463,14 @@ uint64_t devicetree_get_memory(void) {
 
 	i=result;
 
-	temp=big_to_little(tree[i]);
-//	printk("\tValue Length: %x\n",temp);
-	val_len=temp;
-	i++;
-
-	temp=big_to_little(tree[i]);
-	//if (fdt_verbose) printk("\tstring offset: %x\n",temp);
-	i++;
-
 	/* NOTE: should loop if val_len != 8 */
-
-	if (val_len!=8) {
-		printk("ERROR!  Unexpected number of memory entries\n");
-	}
+	do {
+		temp=big_to_little(tree[i]);
+		val_len=temp;
+		i++;
+	} while (val_len != 8);
+	
+	temp=big_to_little(tree[i]);
 
 	if (address_cells==1) {
 		memcpy(&temp,&tree[i],4);

--- a/userspace/Makefile
+++ b/userspace/Makefile
@@ -28,7 +28,7 @@ image:	shell \
 		hello hexdump ll ls md5sum memory_test nano printa printb pwd \
 		rm sysinfo tbo truncate uname write_test chiptune \
 		chiptune6 ./image/bin
-	cp demo.demosplash2019/demosplash2019 ./image/bin
+	#cp demo.demosplash2019/demosplash2019 ./image/bin
 	cp CATME ./image/home
 	cp files/cpuinfo ./image/proc
 	cp files/fstab ./image/etc


### PR DESCRIPTION
This patch fixes an error that I believe is related to memory detection during the boot process on RPi 3B & 3B+.    
It's now possible to (at least) complete the boot process and run the shell on those devices. 